### PR TITLE
Increase read timeout for Documents#create to 2 minutes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,7 @@ require: rubocop-rspec
 
 AllCops:
   TargetRubyVersion: 2.5
+  NewCops: enable
 
 Layout/DotPosition:
   EnforcedStyle: trailing

--- a/lib/plagscan/documents.rb
+++ b/lib/plagscan/documents.rb
@@ -26,7 +26,8 @@ module Plagscan
       Plagscan::Request.json_request(
         'documents',
         method: :post, access_token: access_token, expected_result: Net::HTTPCreated,
-        body: create_props.merge(file ? { fileUpload: file } : { textdata: text })
+        body: create_props.merge(file ? { fileUpload: file } : { textdata: text }),
+        read_timeout: 120
       )
     end
 

--- a/lib/plagscan/request.rb
+++ b/lib/plagscan/request.rb
@@ -43,7 +43,7 @@ module Plagscan
 
       private
 
-      def create_http(options)
+      def create_http(options) # rubocop:disable Metrics/AbcSize
         uri = URI api_url
         http = Net::HTTP.new(uri.host, uri.port)
 
@@ -51,6 +51,10 @@ module Plagscan
           http.use_ssl = true
           http.verify_mode = options[:ssl_verify_mode]
           http.ca_file = options[:ssl_ca_file] if options[:ssl_ca_file]
+        end
+
+        %i[open_timeout write_timeout read_timeout].each do |option|
+          http.__send__("#{option}=", options[option]) if options[option]
         end
 
         http
@@ -68,7 +72,7 @@ module Plagscan
       end
 
       def body_request(uri, headers, options)
-        uri += '?access_token=' + options[:access_token] if options[:access_token]
+        uri += "?access_token=#{options[:access_token]}" if options[:access_token]
         req = http_method(options).new(uri, headers)
         add_body(req, options[:body]) if options[:body]
         req
@@ -77,7 +81,7 @@ module Plagscan
       def uri_request(uri, headers, options)
         body = options[:body] || {}
         body[:access_token] = options[:access_token] if options[:access_token]
-        uri += '?' + body.map { |k, v| "#{k}=#{v}" }.join('&') unless body.empty?
+        uri += "?#{body.map { |k, v| "#{k}=#{v}" }.join('&')}" unless body.empty?
         http_method(options).new(uri, headers)
       end
 

--- a/plagscan.gemspec
+++ b/plagscan.gemspec
@@ -31,8 +31,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'rake', '>= 12.3.3'
   spec.add_development_dependency 'rspec', '~> 3.0'
-  spec.add_development_dependency 'rubocop', '~> 0.74'
-  spec.add_development_dependency 'rubocop-rspec', '~> 1.35'
+  spec.add_development_dependency 'rubocop', '~> 1.28'
+  spec.add_development_dependency 'rubocop-rake', '~> 0.6'
+  spec.add_development_dependency 'rubocop-rspec', '~> 2.10'
   spec.add_development_dependency 'simplecov', '~> 0.17', '< 0.18'
   spec.add_development_dependency 'webmock', '~> 3.0'
 end

--- a/spec/plagscan/documents_spec.rb
+++ b/spec/plagscan/documents_spec.rb
@@ -4,15 +4,23 @@ require 'spec_helper'
 
 describe Plagscan::Documents do
   describe '.create' do
-    it 'calls to PlagScan document create API with token and basic text parameter' do
+    it 'calls to PlagScan document create API with token and basic text parameter' do # rubocop:disable RSpec/ExampleLength
+      allow(Plagscan::Request).to(
+        receive(:json_request).
+          with(
+            'documents',
+            method: :post, access_token: 'my-token', expected_result: Net::HTTPCreated,
+            body: { textdata: 'my excellent document' }, read_timeout: 120
+          ).
+          and_return(id: 1_536_238, Location: 'http://example.com/1536238')
+      )
       expect(Plagscan::Request).to(
         receive(:json_request).
           with(
             'documents',
             method: :post, access_token: 'my-token', expected_result: Net::HTTPCreated,
-            body: { textdata: 'my excellent document' }
-          ).
-          and_return(id: 1_536_238, Location: 'http://example.com/1536238')
+            body: { textdata: 'my excellent document' }, read_timeout: 120
+          )
       )
 
       result = described_class.create(access_token: 'my-token', text: 'my excellent document')
@@ -20,16 +28,24 @@ describe Plagscan::Documents do
       expect(result).to eq(id: 1_536_238, Location: 'http://example.com/1536238')
     end
 
-    it 'calls to PlagScan document create API with token and basic file parameter' do
+    it 'calls to PlagScan document create API with token and basic file parameter' do # rubocop:disable RSpec/ExampleLength
       Tempfile.open('foo') do |file|
+        allow(Plagscan::Request).to(
+          receive(:json_request).
+            with(
+              'documents',
+              method: :post, access_token: 'my-token', expected_result: Net::HTTPCreated,
+              body: { fileUpload: file }, read_timeout: 120
+            ).
+            and_return(id: 1_536_238, Location: 'http://example.com/1536238')
+        )
         expect(Plagscan::Request).to(
           receive(:json_request).
             with(
               'documents',
               method: :post, access_token: 'my-token', expected_result: Net::HTTPCreated,
-              body: { fileUpload: file }
-            ).
-            and_return(id: 1_536_238, Location: 'http://example.com/1536238')
+              body: { fileUpload: file }, read_timeout: 120
+            )
         )
 
         result = described_class.create(access_token: 'my-token', file: file)
@@ -38,16 +54,27 @@ describe Plagscan::Documents do
       end
     end
 
-    it 'accepts optional parameters (filtered)' do
+    it 'accepts optional parameters (filtered)' do # rubocop:disable RSpec/ExampleLength
+      allow(Plagscan::Request).to(
+        receive(:json_request).
+          with(
+            'documents',
+            method: :post, access_token: 'my-token', expected_result: Net::HTTPCreated,
+            body: { textdata: 'my excellent document', userID: 3940,
+                    textname: 'MyFile.docx', toRepository: true, saveOrig: false },
+            read_timeout: 120
+          ).
+          and_return(id: 1_536_238, Location: 'http://example.com/1536238')
+      )
       expect(Plagscan::Request).to(
         receive(:json_request).
           with(
             'documents',
             method: :post, access_token: 'my-token', expected_result: Net::HTTPCreated,
             body: { textdata: 'my excellent document', userID: 3940,
-                    textname: 'MyFile.docx', toRepository: true, saveOrig: false }
-          ).
-          and_return(id: 1_536_238, Location: 'http://example.com/1536238')
+                    textname: 'MyFile.docx', toRepository: true, saveOrig: false },
+            read_timeout: 120
+          )
       )
 
       result =
@@ -91,13 +118,14 @@ describe Plagscan::Documents do
 
   describe '.retrieve' do
     it 'calls to PlagScan document retrieve API with token, document ID and mode' do
+      allow(Plagscan::Request).to(
+        receive(:json_request).
+          with('documents/189/retrieve', access_token: 'my-token', body: { mode: 2 }).
+          and_return(reportData: '<xml>content</xml>')
+      )
       expect(Plagscan::Request).to(
         receive(:json_request).
-          with(
-            'documents/189/retrieve',
-            access_token: 'my-token', body: { mode: 2 }
-          ).
-          and_return(reportData: '<xml>content</xml>')
+          with('documents/189/retrieve', access_token: 'my-token', body: { mode: 2 })
       )
 
       result = described_class.retrieve(access_token: 'my-token', document_id: 189, mode: 2)
@@ -106,13 +134,14 @@ describe Plagscan::Documents do
     end
 
     it 'includes userID if specified' do
+      allow(Plagscan::Request).to(
+        receive(:json_request).
+          with('documents/189/retrieve', access_token: 'my-token', body: { mode: 2, userID: 57 }).
+          and_return(reportData: '<xml>content</xml>')
+      )
       expect(Plagscan::Request).to(
         receive(:json_request).
-          with(
-            'documents/189/retrieve',
-            access_token: 'my-token', body: { mode: 2, userID: 57 }
-          ).
-          and_return(reportData: '<xml>content</xml>')
+          with('documents/189/retrieve', access_token: 'my-token', body: { mode: 2, userID: 57 })
       )
 
       result =

--- a/spec/plagscan/ping_spec.rb
+++ b/spec/plagscan/ping_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-describe Plagscan do
+describe Plagscan do # rubocop:disable RSpec/FilePath
   describe '.ping' do
     subject(:ping) { described_class.ping }
 
@@ -10,13 +10,15 @@ describe Plagscan do
     let(:failure_result) { Net::HTTPBadRequest.new '1', 400, 'fails' }
 
     it 'returns success for a success result' do
-      expect(Plagscan::Request).to receive(:request).with('ping').and_return success_result
-      expect(ping).to eq true
+      allow(Plagscan::Request).to receive(:request).with('ping').and_return success_result
+      expect(Plagscan::Request).to receive(:request).with('ping')
+      expect(ping).to be true
     end
 
     it 'returns failure for a failure result' do
-      expect(Plagscan::Request).to receive(:request).with('ping').and_return failure_result
-      expect(ping).to eq false
+      allow(Plagscan::Request).to receive(:request).with('ping').and_return failure_result
+      expect(Plagscan::Request).to receive(:request).with('ping')
+      expect(ping).to be false
     end
   end
 end

--- a/spec/plagscan/request_spec.rb
+++ b/spec/plagscan/request_spec.rb
@@ -152,7 +152,7 @@ describe Plagscan::Request do
   describe '.json_request' do
     it 'allows just path to be passed through to `request`' do
       stub_request(:get, 'https://api.plagscan.com/v3/my/path').to_return(body: '{"key":"abc"}')
-      if Gem::Version.new(RUBY_VERSION) > Gem::Version.new('2.7.0')
+      if Gem::Version.new(RUBY_VERSION) > Gem::Version.new('2.8.0')
         expect(described_class).to receive(:request).with('my/path').and_call_original
       else
         expect(described_class).to receive(:request).with('my/path', {}).and_call_original

--- a/spec/plagscan/token_spec.rb
+++ b/spec/plagscan/token_spec.rb
@@ -7,10 +7,14 @@ describe Plagscan::Token do
     subject(:fetch) { described_class.fetch client_id: '12345', client_secret: 'abcde' }
 
     it 'calls to PlagScan token API with credentials' do
-      expect(Plagscan::Request).to(
+      allow(Plagscan::Request).to(
         receive(:json_request).
           with('token', method: :post, body: { client_id: '12345', client_secret: 'abcde' }).
           and_return(access_token: 'your_token', expires_in: 3600)
+      )
+      expect(Plagscan::Request).to(
+        receive(:json_request).
+          with('token', method: :post, body: { client_id: '12345', client_secret: 'abcde' })
       )
 
       expect(fetch).to eq(access_token: 'your_token', expires_in: 3600)


### PR DESCRIPTION
Allow specifying open/write/read timeout options in request API calls
Address some code lints

Of late PlagScan calls have been taking more than 60 seconds (default) to return a response. Increasing the timeout to 120 seconds *should* help